### PR TITLE
Fix case where nicknames don't show up on large teams

### DIFF
--- a/irc_context.go
+++ b/irc_context.go
@@ -89,12 +89,19 @@ func (ic IrcContext) Mask() string {
 func (ic IrcContext) UserIDsToNames(userIDs ...string) []string {
 	var names []string
 	// TODO implement using ic.GetUsers() instead
+	allUsers := ic.GetUsers(true)
+	usersMap := make(map[string]slack.User, len(allUsers))
+	for _, user := range allUsers {
+		usersMap[user.ID] = user
+	}
 	for _, uid := range userIDs {
-		user, err := ic.SlackClient.GetUserInfo(uid)
-		if err != nil {
+		user, ok := usersMap[uid]
+		if !ok {
 			names = append(names, uid)
+			log.Printf("Could not fetch user %s", uid)
 		} else {
 			names = append(names, user.Name)
+			log.Printf("Fetched info for user ID %s: %s", uid, user.Name)
 		}
 	}
 	return names

--- a/irc_server.go
+++ b/irc_server.go
@@ -268,7 +268,7 @@ func IrcAfterLoggingIn(ctx *IrcContext, rtm *slack.RTM) error {
 				log.Printf("Disconnected from Slack (intentional: %v)", msg.Data.(*slack.DisconnectedEvent).Intentional)
 				ctx.SlackConnected = false
 				ctx.Conn.Close()
-			case *slack.ChannelJoinedEvent, *slack.ChannelLeftEvent:
+			case *slack.MemberJoinedChannelEvent, *slack.MemberLeftChannelEvent:
 				// refresh the users list
 				// FIXME also send a JOIN / PART message to the IRC client
 				ctx.GetUsers(true)

--- a/irc_server.go
+++ b/irc_server.go
@@ -148,11 +148,28 @@ func IrcAfterLoggingIn(ctx *IrcContext, rtm *slack.RTM) error {
 		for _, ch := range channels {
 			var info string
 			if ch.IsMember {
+				var (
+					members, m []string
+					nextCursor string
+					err        error
+				)
+				for {
+					m, nextCursor, err = ctx.SlackClient.GetUsersInConversation(&slack.GetUsersInConversationParameters{ChannelID: ch.ID, Cursor: nextCursor})
+					if err != nil {
+						log.Printf("Cannot get member list for channel %s: %v", ch.Name, err)
+						break
+					}
+					members = append(members, m...)
+					log.Printf(" nextCursor=%v", nextCursor)
+					if nextCursor == "" {
+						break
+					}
+				}
 				info = "(joined) "
-				info += fmt.Sprintf(" topic=%s ", ch.Topic.Value)
+				info += fmt.Sprintf(" topic=%s members=%d", ch.Topic.Value, len(members))
 				// the channels are already joined, notify the IRC client of their
 				// existence
-				go IrcSendChanInfoAfterJoin(ctx, ch.Name, ch.Topic.Value, ch.Members, false)
+				go IrcSendChanInfoAfterJoin(ctx, ch.Name, ch.Topic.Value, members, false)
 			}
 			log.Printf("  #%v %v", ch.Name, info)
 		}


### PR DESCRIPTION
If a Slack team is large, not all the nicknames are fetched. See https://github.com/insomniacslk/irc-slack/issues/11 for background.

This also depends on https://github.com/nlopes/slack/issues/317 on the underlying Slack library.