### PR TITLE
Refactored connection to Slack

### DIFF
--- a/irc_context.go
+++ b/irc_context.go
@@ -16,6 +16,7 @@ type IrcContext struct {
 	UserName       string
 	RealName       string
 	SlackClient    *slack.Client
+	SlackRTM       *slack.RTM
 	SlackAPIKey    string
 	SlackConnected bool
 	ServerName     string
@@ -118,6 +119,5 @@ func (ic IrcContext) UserIDsToNames(userIDs ...string) []string {
 
 // Maps of user contexts and nicknames
 var (
-	UserContexts  = map[net.Addr]*IrcContext{}
-	UserNicknames = map[string]*IrcContext{}
+	UserContexts = map[net.Addr]*IrcContext{}
 )

--- a/server.go
+++ b/server.go
@@ -43,9 +43,8 @@ func (s Server) HandleRequest(conn *net.TCPConn) {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			// clean up this client's state
-			if ctx, ok := UserContexts[conn.RemoteAddr()]; ok {
+			if _, ok := UserContexts[conn.RemoteAddr()]; ok {
 				// remove from user contexts and users list
-				delete(UserNicknames, ctx.Nick)
 				delete(UserContexts, conn.RemoteAddr())
 			}
 			if err == io.EOF {


### PR DESCRIPTION
Multiple changes around connecting to the Slack server:
* refactored connection to Slack into its own function `connectToSlack`
* added RTM information to the IrcContext object
* Using the nickname provided by Slack
* printing team name upon connection
* removed useless UserNicknames