### PR TITLE
Workaround for chat.meMessage API bug

### DIFF
--- a/irc_channel.go
+++ b/irc_channel.go
@@ -5,6 +5,7 @@ package main
 type Channel struct {
 	Members []string
 	Topic   string
+	ID      string
 	// Slack groups are different from channels. Here I try to uniform them for
 	// IRC, but I still need to know which is which to use the right API calls.
 	IsGroup bool

--- a/irc_server.go
+++ b/irc_server.go
@@ -279,12 +279,12 @@ func IrcPrivMsgHandler(ctx *IrcContext, prefix, cmd string, args []string, trail
 		if strings.HasPrefix(target, "#") {
 			key = target[1:]
 		}
-		if ch, ok := ctx.Channels[key]; !ok {
+		ch, ok := ctx.Channels[key]
+		if !ok {
 			log.Printf("Error: unknown channel ID for %s", key)
 			return
-		} else {
-			target = ch.ID
 		}
+		target = ch.ID
 
 		// this is a MeMessage
 		// strip off the ACTION and \x01 wrapper


### PR DESCRIPTION
Implemented workaround for a small Slack API bug that affects chat.meMessage .

I've discussed the bug over email with the Slack technical support (thank you Sandra!),
and they've been very helpful in confirming the bug and reporting it internally. As per
their investigation, the chat.meMessage API at the moment requires a channel ID to
work, while the documentation reports that both channel ID and name would work.
The bug has been reported internally and it will be fixed. Meanwhile this patch lets
me-messages work until the fix on the remote end.

This is a follow-up to https://github.com/insomniacslk/irc-slack/pull/39