### PR TITLE
support both \r\n and \n for commands

### DIFF
--- a/server.go
+++ b/server.go
@@ -76,11 +76,14 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 		prefix = ""
 		data = msg
 	}
-	if !strings.HasSuffix(data, "\r\n") {
-		log.Print("Invalid data: not terminated with <CR><LF>")
+	if strings.HasSuffix(data, "\r\n") {
+		data = data[:len(data)-2]
+	} else if strings.HasSuffix(data, "\n") {
+		data = data[:len(data)-1]
+	} else {
+		log.Print("Invalid data: not terminated with <CR><LF> or <LF>")
 		return
 	}
-	data = data[:len(data)-2]
 
 	tokens := strings.Split(data, " ")
 	cmd := tokens[0]


### PR DESCRIPTION
So I use the self-hosted web client called thelounge (thelounge/thelounge), which in turn uses the irc-framework node module.

It looks like they only write out \n not \r\n even though the spec says you are supposed to \r\n

https://github.com/kiwiirc/irc-framework/blob/89aee181ec9b79014f322e62786ae3d833d3af1e/src/transports/net.js#L37-L45

So just a quick fix to handle both.