### PR TITLE
Batch messages sent to slack

### DIFF
--- a/irc_server.go
+++ b/irc_server.go
@@ -345,7 +345,6 @@ func IrcPrivMsgHandler(ctx *IrcContext, prefix, cmd string, args []string, trail
 
 	text := trailing
 
-	opts := []slack.MsgOption{}
 	if strings.HasPrefix(text, "\x01ACTION ") && strings.HasSuffix(text, "\x01") {
 		// The Slack API has a bug, where a chat.meMessage is
 		// documented to accept a channel name or ID, but actually
@@ -375,14 +374,8 @@ func IrcPrivMsgHandler(ctx *IrcContext, prefix, cmd string, args []string, trail
 		//      and remove the italic text
 		//opts = append(opts, slack.MsgOptionMeMessage())
 		text = "_" + text + "_"
-		opts = append(opts, slack.MsgOptionAsUser(true))
-	} else {
-		opts = append(opts, slack.MsgOptionAsUser(true))
 	}
-	text = parseMentions(text)
-	opts = append(opts, slack.MsgOptionText(text, false))
-
-	ctx.SlackClient.PostMessage(target, opts...)
+	ctx.PostTextMessage(target, parseMentions(text))
 }
 
 func connectToSlack(ctx *IrcContext) error {

--- a/server.go
+++ b/server.go
@@ -107,8 +107,10 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 			ServerName:        s.Name,
 			SlackAPIKey:       s.SlackAPIKey,
 			ChunkSize:         s.ChunkSize,
+			postMessage:       make(chan SlackPostMessage),
 			conversationCache: make(map[string]*slack.Channel),
 		}
+		go ctx.Start()
 		UserContexts[conn.RemoteAddr()] = ctx
 	}
 	handler(ctx, prefix, cmd, args, trailing)


### PR DESCRIPTION
This allows sending multiple consecutive messages as a single multiline message to slack api.
I find this useful for sending code snippets that span multiple lines.