### PR TITLE
Add options to download and rewrite attachment urls

### DIFF
--- a/event_handler.go
+++ b/event_handler.go
@@ -125,7 +125,7 @@ func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 				text = joinText(text, attachment.ImageURL, "\n")
 			}
 			for _, file := range ev.Msg.Files {
-				text = joinText(text, file.URLPrivate, " ")
+				text = joinText(text, ctx.FileHandler.Download(file), " ")
 			}
 
 			log.Printf("SLACK msg from %v (%v) on %v: %v",

--- a/file_handler.go
+++ b/file_handler.go
@@ -62,7 +62,7 @@ func (handler *FileHandler) Download(file slack.File) string {
 	go func() {
 		out, err := os.Create(localFilePath)
 		if err != nil {
-			log.Printf("Could not create file for download %s", localFilePath)
+			log.Printf("Could not create file for download %s: %v", localFilePath, err)
 			return
 		}
 
@@ -80,7 +80,7 @@ func (handler *FileHandler) Download(file slack.File) string {
 			if err == nil {
 				break
 			}
-			log.Printf("Error downloading %v", file)
+			log.Printf("Error downloading %s: %v", fileURL, err)
 			return
 		}
 		if resp.StatusCode != http.StatusOK {
@@ -90,7 +90,7 @@ func (handler *FileHandler) Download(file slack.File) string {
 		defer resp.Body.Close()
 		_, err = io.Copy(out, resp.Body)
 		if err != nil {
-			log.Printf("Error writing %s", fileURL)
+			log.Printf("Error writing %s: %v", fileURL, err)
 		}
 		return
 	}()

--- a/file_handler.go
+++ b/file_handler.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/nlopes/slack"
+)
+
+// FileHandler downloads files from slack
+type FileHandler struct {
+	SlackAPIKey          string
+	FileDownloadLocation string
+	ProxyPrefix          string
+}
+
+// Download downloads url contents to a local file
+func (handler *FileHandler) Download(file slack.File) string {
+	fileUrl := file.URLPrivate
+	if handler.FileDownloadLocation == "" {
+		return fileUrl
+	}
+	if handler.SlackAPIKey == "" {
+		return fileUrl
+	}
+	if file.IsExternal {
+		return fileUrl
+	}
+	localFileName := fmt.Sprintf("%s_%s.%s", file.ID, file.Title, file.Filetype)
+	localFilePath := filepath.Join(handler.FileDownloadLocation, localFileName)
+	go func() {
+		out, err := os.Create(localFilePath)
+		if err != nil {
+			log.Printf("Could not create file for download %s", localFilePath)
+			return
+		}
+
+		defer out.Close()
+		request, _ := http.NewRequest("GET", fileUrl, nil)
+		request.Header.Add("Authorization", "Bearer "+handler.SlackAPIKey)
+		var client = &http.Client{}
+		resp, err := client.Do(request)
+		if err != nil {
+			log.Printf("Error downloading %v", file)
+			return
+		}
+		if resp.StatusCode != http.StatusOK {
+			log.Printf("Got %d while downloading %s", resp.StatusCode, fileUrl)
+			return
+		}
+		defer resp.Body.Close()
+		_, err = io.Copy(out, resp.Body)
+		if err != nil {
+			log.Printf("Error writing %s", fileUrl)
+		}
+		return
+	}()
+	if handler.ProxyPrefix != "" {
+		return handler.ProxyPrefix + url.PathEscape(localFileName)
+	}
+	return fileUrl
+}

--- a/file_handler.go
+++ b/file_handler.go
@@ -59,7 +59,7 @@ func (handler *FileHandler) Download(file slack.File) string {
 	}
 	localFileName := fmt.Sprintf("%s_%s", file.ID, file.Title)
 	if !strings.HasSuffix(localFileName, file.Filetype) {
-		localFileName += file.FileType
+		localFileName += file.Filetype
 	}
 	localFilePath := filepath.Join(handler.FileDownloadLocation, localFileName)
 	go func() {

--- a/file_handler.go
+++ b/file_handler.go
@@ -19,16 +19,11 @@ type FileHandler struct {
 	ProxyPrefix          string
 }
 
-// Download downloads url contents to a local file
+// Download downloads url contents to a local file and returns a url to either
+// the file on slack's server or a downloaded file
 func (handler *FileHandler) Download(file slack.File) string {
 	fileURL := file.URLPrivate
-	if handler.FileDownloadLocation == "" {
-		return fileURL
-	}
-	if handler.SlackAPIKey == "" {
-		return fileURL
-	}
-	if file.IsExternal {
+	if handler.FileDownloadLocation == "" || file.IsExternal || handler.SlackAPIKey == "" {
 		return fileURL
 	}
 	localFileName := fmt.Sprintf("%s_%s.%s", file.ID, file.Title, file.Filetype)

--- a/file_handler.go
+++ b/file_handler.go
@@ -57,7 +57,10 @@ func (handler *FileHandler) Download(file slack.File) string {
 	if handler.FileDownloadLocation == "" || file.IsExternal || handler.SlackAPIKey == "" {
 		return fileURL
 	}
-	localFileName := fmt.Sprintf("%s_%s.%s", file.ID, file.Title, file.Filetype)
+	localFileName := fmt.Sprintf("%s_%s", file.ID, file.Title)
+	if !strings.HasSuffix(localFileName, file.Filetype) {
+		localFileName += file.FileType
+	}
 	localFilePath := filepath.Join(handler.FileDownloadLocation, localFileName)
 	go func() {
 		out, err := os.Create(localFilePath)

--- a/file_handler.go
+++ b/file_handler.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/nlopes/slack"

--- a/file_handler.go
+++ b/file_handler.go
@@ -21,15 +21,15 @@ type FileHandler struct {
 
 // Download downloads url contents to a local file
 func (handler *FileHandler) Download(file slack.File) string {
-	fileUrl := file.URLPrivate
+	fileURL := file.URLPrivate
 	if handler.FileDownloadLocation == "" {
-		return fileUrl
+		return fileURL
 	}
 	if handler.SlackAPIKey == "" {
-		return fileUrl
+		return fileURL
 	}
 	if file.IsExternal {
-		return fileUrl
+		return fileURL
 	}
 	localFileName := fmt.Sprintf("%s_%s.%s", file.ID, file.Title, file.Filetype)
 	localFilePath := filepath.Join(handler.FileDownloadLocation, localFileName)
@@ -41,7 +41,7 @@ func (handler *FileHandler) Download(file slack.File) string {
 		}
 
 		defer out.Close()
-		request, _ := http.NewRequest("GET", fileUrl, nil)
+		request, _ := http.NewRequest("GET", fileURL, nil)
 		request.Header.Add("Authorization", "Bearer "+handler.SlackAPIKey)
 		var client = &http.Client{}
 		resp, err := client.Do(request)
@@ -50,18 +50,18 @@ func (handler *FileHandler) Download(file slack.File) string {
 			return
 		}
 		if resp.StatusCode != http.StatusOK {
-			log.Printf("Got %d while downloading %s", resp.StatusCode, fileUrl)
+			log.Printf("Got %d while downloading %s", resp.StatusCode, fileURL)
 			return
 		}
 		defer resp.Body.Close()
 		_, err = io.Copy(out, resp.Body)
 		if err != nil {
-			log.Printf("Error writing %s", fileUrl)
+			log.Printf("Error writing %s", fileURL)
 		}
 		return
 	}()
 	if handler.ProxyPrefix != "" {
 		return handler.ProxyPrefix + url.PathEscape(localFileName)
 	}
-	return fileUrl
+	return fileURL
 }

--- a/irc_context.go
+++ b/irc_context.go
@@ -25,6 +25,7 @@ type IrcContext struct {
 	Users             []slack.User
 	ChunkSize         int
 	conversationCache map[string]*slack.Channel
+	FileHandler       *FileHandler
 }
 
 // Nick returns the nickname of the user, if known

--- a/irc_server.go
+++ b/irc_server.go
@@ -503,6 +503,7 @@ func IrcPassHandler(ctx *IrcContext, prefix, cmd string, args []string, trailing
 		return
 	}
 	ctx.SlackAPIKey = args[0]
+	ctx.FileHandler.SlackAPIKey = ctx.SlackAPIKey
 }
 
 // IrcWhoisHandler is called when a WHOIS command is sent

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"net"
+	"os"
 )
 
 // TODO handle expired Slack RTM sessions (e.g. after standby/resume)
@@ -42,6 +43,12 @@ func main() {
 	}
 	localAddr.IP = ip
 	log.Printf("Starting server on %v", localAddr.String())
+	if *fileDownloadLocation != "" {
+		dInfo, err := os.Stat(*fileDownloadLocation)
+		if err != nil || !dInfo.IsDir() {
+			log.Fatalf("Missing or invalid download directory: %s", *fileDownloadLocation)
+		}
+	}
 	server := Server{
 		LocalAddr:            &localAddr,
 		Name:                 sName,

--- a/main.go
+++ b/main.go
@@ -18,10 +18,12 @@ import (
 // legacy token for the desired team. See
 // https://api.slack.com/custom-integrations/legacy-tokens
 var (
-	port       = flag.Int("p", 6666, "Local port to listen on")
-	host       = flag.String("H", "127.0.0.1", "IP address to listen on")
-	serverName = flag.String("s", "", "IRC server name (i.e. the host name to send to clients)")
-	chunkSize  = flag.Int("chunk", 512, "Maximum size of a line to send to the client. Only works for certain reply types")
+	port                 = flag.Int("p", 6666, "Local port to listen on")
+	host                 = flag.String("H", "127.0.0.1", "IP address to listen on")
+	serverName           = flag.String("s", "", "IRC server name (i.e. the host name to send to clients)")
+	chunkSize            = flag.Int("chunk", 512, "Maximum size of a line to send to the client. Only works for certain reply types")
+	fileDownloadLocation = flag.String("d", "", "If set will download attachments to this location")
+	fileProxyPrefix      = flag.String("l", "", "If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d")
 )
 
 func main() {
@@ -41,9 +43,11 @@ func main() {
 	localAddr.IP = ip
 	log.Printf("Starting server on %v", localAddr.String())
 	server := Server{
-		LocalAddr: &localAddr,
-		Name:      sName,
-		ChunkSize: *chunkSize,
+		LocalAddr:            &localAddr,
+		Name:                 sName,
+		ChunkSize:            *chunkSize,
+		FileDownloadLocation: *fileDownloadLocation,
+		FileProxyPrefix:      *fileProxyPrefix,
 	}
 	if err := server.Start(); err != nil {
 		log.Fatal(err)

--- a/server.go
+++ b/server.go
@@ -13,11 +13,13 @@ import (
 
 // Server is the server object that exposes the Slack API with an IRC interface.
 type Server struct {
-	Name        string
-	LocalAddr   net.Addr
-	Listener    *net.TCPListener
-	SlackAPIKey string
-	ChunkSize   int
+	Name                 string
+	LocalAddr            net.Addr
+	Listener             *net.TCPListener
+	SlackAPIKey          string
+	ChunkSize            int
+	FileDownloadLocation string
+	FileProxyPrefix      string
 }
 
 // Start runs the IRC server
@@ -102,12 +104,18 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 	}
 	ctx, ok := UserContexts[conn.RemoteAddr()]
 	if !ok || ctx == nil {
+		log.Printf("!!! SlackApiKey %v", s.SlackAPIKey)
 		ctx = &IrcContext{
 			Conn:              conn,
 			ServerName:        s.Name,
 			SlackAPIKey:       s.SlackAPIKey,
 			ChunkSize:         s.ChunkSize,
 			conversationCache: make(map[string]*slack.Channel),
+			FileHandler: &FileHandler{
+				SlackAPIKey:          s.SlackAPIKey,
+				FileDownloadLocation: s.FileDownloadLocation,
+				ProxyPrefix:          s.FileProxyPrefix,
+			},
 		}
 		UserContexts[conn.RemoteAddr()] = ctx
 	}

--- a/server.go
+++ b/server.go
@@ -104,7 +104,6 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 	}
 	ctx, ok := UserContexts[conn.RemoteAddr()]
 	if !ok || ctx == nil {
-		log.Printf("!!! SlackApiKey %v", s.SlackAPIKey)
 		ctx = &IrcContext{
 			Conn:              conn,
 			ServerName:        s.Name,


### PR DESCRIPTION
This adds option to provide a download location for message attachments.
If the option is set any received attachments will be automaticaly
downloaded to the specified location.

Additional to that there's an option to rewrite attachments urls. This
is useful in case you run a server that hosts downloaded files and want
to access the files without accessing slacks private file url.

Let me know if you find this useful or not, I'm open the changing the PR.