### PR TITLE
Add basic support for slack threads

### DIFF
--- a/event_handler.go
+++ b/event_handler.go
@@ -66,7 +66,7 @@ func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 						IrcSendChanInfoAfterJoin(
 							ctx,
 							channame,
-							channame,
+							ev.Msg.Channel,
 							openingText,
 							[]string{},
 							true,

--- a/event_handler.go
+++ b/event_handler.go
@@ -28,6 +28,10 @@ func formatMultipartyChannelName(slackChannelID string, slackChannelName string)
 	return name
 }
 
+func formatThreadChannelName(msg slack.Msg, channel *slack.Channel) string {
+	return "+" + channel.Name + "-" + msg.ThreadTimestamp
+}
+
 func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 	log.Print("Started Slack event listener")
 	for msg := range rtm.IncomingEvents {
@@ -42,19 +46,39 @@ func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 			} else {
 				name = user.Name
 			}
+
 			// get channel or other recipient (e.g. recipient of a direct message)
 			var channame string
+			text := ""
 			if strings.HasPrefix(ev.Msg.Channel, "C") || strings.HasPrefix(ev.Msg.Channel, "G") {
 				// Channel message
 				channel, err := ctx.GetConversationInfo(ev.Msg.Channel)
+
 				if err != nil {
 					log.Printf("Error getting channel info for %v: %v", ev.Msg.Channel, err)
 					channame = "unknown"
+				} else if ev.Msg.ThreadTimestamp != "" {
+					log.Printf("This is a message in a thread %v", ev.Msg)
+					channame = formatThreadChannelName(ev.Msg, channel)
+					_, ok := ctx.Channels[channame]
+					if !ok {
+						openingText := ctx.GetThreadOpener(ev.Msg)
+						IrcSendChanInfoAfterJoin(
+							ctx,
+							channame,
+							channame,
+							openingText,
+							[]string{},
+							true,
+						)
+
+						text += openingText + "\n"
+					}
 				} else if channel.IsMpIM {
 					channame = formatMultipartyChannelName(ev.Msg.Channel, channel.Name)
 					_, ok := ctx.Channels[channame]
 					if !ok {
-						go IrcSendChanInfoAfterJoin(
+						IrcSendChanInfoAfterJoin(
 							ctx,
 							channame,
 							ev.Msg.Channel,
@@ -113,7 +137,7 @@ func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 				continue
 			}
 
-			text := ev.Msg.Text
+			text += ev.Msg.Text
 			for _, attachment := range ev.Msg.Attachments {
 				text = joinText(text, attachment.Pretext, "\n")
 				text = joinText(text, attachment.Title, "\n")

--- a/irc_context.go
+++ b/irc_context.go
@@ -69,6 +69,18 @@ func (ic *IrcContext) GetUsers(refresh bool) []slack.User {
 	return ic.Users
 }
 
+// GetThreadOpener returns text of the first message in a thread that provided message belongs to
+func (ic *IrcContext) GetThreadOpener(msg slack.Msg) string {
+	msgs, _, _, err := ic.SlackClient.GetConversationReplies(&slack.GetConversationRepliesParameters{
+		ChannelID: msg.Channel,
+		Timestamp: msg.ThreadTimestamp,
+	})
+	if err != nil || len(msgs) == 0 {
+		return ""
+	}
+	return msgs[0].Text
+}
+
 // Start handles batching of messages to slack
 func (ic *IrcContext) Start() {
 	textBuffer := make(map[string]string)

--- a/irc_context.go
+++ b/irc_context.go
@@ -13,8 +13,9 @@ import (
 
 // SlackPostMessage represents a message sent to slack api
 type SlackPostMessage struct {
-	Target string
-	Text   string
+	Target   string
+	TargetTs string
+	Text     string
 }
 
 // IrcContext holds the client context information
@@ -97,6 +98,9 @@ func (ic *IrcContext) Start() {
 				opts := []slack.MsgOption{}
 				opts = append(opts, slack.MsgOptionAsUser(true))
 				opts = append(opts, slack.MsgOptionText(strings.TrimSpace(text), false))
+				if message.TargetTs != "" {
+					opts = append(opts, slack.MsgOptionTS(message.TargetTs))
+				}
 				ic.SlackClient.PostMessage(target, opts...)
 			}
 			textBuffer = make(map[string]string)
@@ -105,10 +109,11 @@ func (ic *IrcContext) Start() {
 }
 
 // PostTextMessage batches all messages that should be posted to slack
-func (ic *IrcContext) PostTextMessage(target string, text string) {
+func (ic *IrcContext) PostTextMessage(target, text, targetTs string) {
 	ic.postMessage <- SlackPostMessage{
-		Target: target,
-		Text:   text,
+		Target:   target,
+		TargetTs: targetTs,
+		Text:     text,
 	}
 }
 

--- a/irc_server.go
+++ b/irc_server.go
@@ -330,6 +330,14 @@ func parseMentions(text string) string {
 	return strings.Join(tokens, " ")
 }
 
+func getTargetTs(channelName string) string {
+	if !strings.HasPrefix(channelName, "+") {
+		return ""
+	}
+	chanNameSplit := strings.Split(channelName, "-")
+	return chanNameSplit[len(chanNameSplit)-1]
+}
+
 // IrcPrivMsgHandler is called when a PRIVMSG command is sent
 func IrcPrivMsgHandler(ctx *IrcContext, prefix, cmd string, args []string, trailing string) {
 	if len(args) != 1 {
@@ -375,7 +383,11 @@ func IrcPrivMsgHandler(ctx *IrcContext, prefix, cmd string, args []string, trail
 		//opts = append(opts, slack.MsgOptionMeMessage())
 		text = "_" + text + "_"
 	}
-	ctx.PostTextMessage(target, parseMentions(text))
+	ctx.PostTextMessage(
+		target,
+		parseMentions(text),
+		getTargetTs(args[0]),
+	)
 }
 
 func connectToSlack(ctx *IrcContext) error {


### PR DESCRIPTION
Closes #63 
As described in the original issue, I've added support for threads as separate IRC channels. 
Thread channel name is the name of the original channel combined with timestamp of the first message in the thread and prefixed with `+`. Eg: `+general-1234567.000`. IMO this makes it easier to identify threads for each channel. First message in the channel reflects the first message in slack thread. 