### PR TITLE
Added -D for debug messages

### DIFF
--- a/file_handler.go
+++ b/file_handler.go
@@ -65,7 +65,7 @@ func (handler *FileHandler) Download(file slack.File) string {
 	go func() {
 		out, err := os.Create(localFilePath)
 		if err != nil {
-			log.Printf("Could not create file for download %s: %v", localFilePath, err)
+			log.Warningf("Could not create file for download %s: %v", localFilePath, err)
 			return
 		}
 
@@ -83,17 +83,17 @@ func (handler *FileHandler) Download(file slack.File) string {
 			if err == nil {
 				break
 			}
-			log.Printf("Error downloading %s: %v", fileURL, err)
+			log.Warningf("Error downloading %s: %v", fileURL, err)
 			return
 		}
 		if resp.StatusCode != http.StatusOK {
-			log.Printf("Got %d while downloading %s", resp.StatusCode, fileURL)
+			log.Debugf("Got %d while downloading %s", resp.StatusCode, fileURL)
 			return
 		}
 		defer resp.Body.Close()
 		_, err = io.Copy(out, resp.Body)
 		if err != nil {
-			log.Printf("Error writing %s: %v", fileURL, err)
+			log.Warningf("Error writing %s: %v", fileURL, err)
 		}
 		return
 	}()

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -293,6 +294,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/irc_context.go
+++ b/irc_context.go
@@ -60,11 +60,11 @@ func (ic *IrcContext) GetUsers(refresh bool) []slack.User {
 	if refresh || ic.Users == nil || len(ic.Users) == 0 {
 		users, err := ic.SlackClient.GetUsers()
 		if err != nil {
-			log.Printf("Failed to get users: %v", err)
+			log.Warningf("Failed to get users: %v", err)
 			return nil
 		}
 		ic.Users = users
-		log.Printf("Fetched %v users", len(users))
+		log.Infof("Fetched %v users", len(users))
 	}
 	return ic.Users
 }
@@ -101,7 +101,7 @@ func (ic *IrcContext) Start() {
 	for {
 		select {
 		case message = <-ic.postMessage:
-			log.Printf("Got new message %v", message)
+			log.Debugf("Got new message %v", message)
 			textBuffer[message.Target] += message.Text + "\n"
 			timer.Reset(time.Second)
 		case <-timer.C:
@@ -186,10 +186,10 @@ func (ic IrcContext) UserIDsToNames(userIDs ...string) []string {
 		user, ok := usersMap[uid]
 		if !ok {
 			names = append(names, uid)
-			log.Printf("Could not fetch user %s, not in user map", uid)
+			log.Warningf("Could not fetch user %s, not in user map", uid)
 		} else {
 			names = append(names, user.Name)
-			log.Printf("Fetched info for user ID %s: %s", uid, user.Name)
+			log.Infof("Fetched info for user ID %s: %s", uid, user.Name)
 		}
 	}
 	return names

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/coredhcp/coredhcp/logger"
+	"github.com/sirupsen/logrus"
 )
 
 // TODO handle expired Slack RTM sessions (e.g. after standby/resume)
@@ -26,12 +27,18 @@ var (
 	chunkSize            = flag.Int("chunk", 512, "Maximum size of a line to send to the client. Only works for certain reply types")
 	fileDownloadLocation = flag.String("d", "", "If set will download attachments to this location")
 	fileProxyPrefix      = flag.String("l", "", "If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d")
+	doDebug              = flag.Bool("D", false, "Enable debug logging")
 )
 
 var log = logger.GetLogger("main")
 
 func main() {
 	flag.Parse()
+
+	if *doDebug {
+		log.Logger.SetLevel(logrus.DebugLevel)
+		log.Info("Enable debug logging")
+	}
 
 	var sName string
 	if *serverName == "" {
@@ -42,7 +49,7 @@ func main() {
 	localAddr := net.TCPAddr{Port: *port}
 	ip := net.ParseIP(*host)
 	if ip == nil {
-		log.Fatal("Invalid IP address to listen on")
+		log.Fatalf("Invalid IP address to listen on: '%s'", *host)
 	}
 	localAddr.IP = ip
 	log.Printf("Starting server on %v", localAddr.String())

--- a/server.go
+++ b/server.go
@@ -29,7 +29,7 @@ func (s Server) Start() error {
 	}
 	s.Listener = listener.(*net.TCPListener)
 	defer s.Listener.Close()
-	log.Printf("Listening on %v", s.LocalAddr)
+	log.Infof("Listening on %v", s.LocalAddr)
 	for {
 		conn, err := s.Listener.Accept()
 		if err != nil {
@@ -52,10 +52,10 @@ func (s Server) HandleRequest(conn *net.TCPConn) {
 				delete(UserContexts, conn.RemoteAddr())
 			}
 			if err == io.EOF {
-				log.Printf("Client %v disconnected", conn.RemoteAddr())
+				log.Warningf("Client %v disconnected", conn.RemoteAddr())
 				break
 			}
-			log.Printf("Error handling connection from %v: %v", conn.RemoteAddr(), err)
+			log.Warningf("Error handling connection from %v: %v", conn.RemoteAddr(), err)
 			break
 		}
 		s.HandleMsg(conn, string(line))
@@ -64,9 +64,9 @@ func (s Server) HandleRequest(conn *net.TCPConn) {
 
 // HandleMsg handles raw IRC messages
 func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
-	log.Printf("%v: %v", conn.RemoteAddr(), msg)
+	log.Debugf("%v: %v", conn.RemoteAddr(), msg)
 	if len(msg) < 1 {
-		log.Printf("Invalid message: '%v'", msg)
+		log.Warningf("Invalid message: '%v'", msg)
 		return
 	}
 	var (
@@ -80,7 +80,7 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 		data = msg
 	}
 	if !strings.HasSuffix(data, "\r\n") {
-		log.Print("Invalid data: not terminated with <CR><LF>")
+		log.Warning("Invalid data: not terminated with <CR><LF>")
 		return
 	}
 	data = data[:len(data)-2]
@@ -98,7 +98,7 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 	}
 	handler, ok := IrcCommandHandlers[cmd]
 	if !ok {
-		log.Printf("No handler found for %v", cmd)
+		log.Warningf("No handler found for %v", cmd)
 		return
 	}
 	ctx, ok := UserContexts[conn.RemoteAddr()]


### PR DESCRIPTION
Now every log line has an explicit logging level. Debug messages are not
printed by default, but can be enabled with -D.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>