### PR TITLE
Add flag to enable Slack API debugging

### DIFF
--- a/irc_context.go
+++ b/irc_context.go
@@ -26,7 +26,7 @@ type IrcContext struct {
 	SlackClient       *slack.Client
 	SlackRTM          *slack.RTM
 	SlackAPIKey       string
-	SlackDebug bool
+	SlackDebug        bool
 	SlackConnected    bool
 	ServerName        string
 	Channels          map[string]Channel

--- a/irc_context.go
+++ b/irc_context.go
@@ -26,6 +26,7 @@ type IrcContext struct {
 	SlackClient       *slack.Client
 	SlackRTM          *slack.RTM
 	SlackAPIKey       string
+	SlackDebug bool
 	SlackConnected    bool
 	ServerName        string
 	Channels          map[string]Channel

--- a/irc_server.go
+++ b/irc_server.go
@@ -428,7 +428,11 @@ func (l *loggerWrapper) Output(calldepth int, s string) error {
 }
 
 func connectToSlack(ctx *IrcContext) error {
-	ctx.SlackClient = slack.New(ctx.SlackAPIKey, slack.OptionDebug(false), slack.OptionLog(&loggerWrapper{log.Logger}))
+	ctx.SlackClient = slack.New(
+		ctx.SlackAPIKey,
+		slack.OptionDebug(ctx.SlackDebug),
+		slack.OptionLog(&loggerWrapper{log.Logger}),
+	)
 	rtm := ctx.SlackClient.NewRTM()
 	ctx.SlackRTM = rtm
 	go rtm.ManageConnection()

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 	fileDownloadLocation = flag.String("d", "", "If set will download attachments to this location")
 	fileProxyPrefix      = flag.String("l", "", "If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d")
 	logLevel             = flag.String("L", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
-	flagSlackDebug = flag.Bool("D", false, "Enable debug logging of the Slack API")
+	flagSlackDebug       = flag.Bool("D", false, "Enable debug logging of the Slack API")
 )
 
 var log = logger.GetLogger("main")
@@ -86,7 +86,7 @@ func main() {
 		ChunkSize:            *chunkSize,
 		FileDownloadLocation: *fileDownloadLocation,
 		FileProxyPrefix:      *fileProxyPrefix,
-		SlackDebug: *flagSlackDebug,
+		SlackDebug:           *flagSlackDebug,
 	}
 	if err := server.Start(); err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	fileDownloadLocation = flag.String("d", "", "If set will download attachments to this location")
 	fileProxyPrefix      = flag.String("l", "", "If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d")
 	logLevel             = flag.String("L", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
+	flagSlackDebug = flag.Bool("D", false, "Enable debug logging of the Slack API")
 )
 
 var log = logger.GetLogger("main")
@@ -85,6 +86,7 @@ func main() {
 		ChunkSize:            *chunkSize,
 		FileDownloadLocation: *fileDownloadLocation,
 		FileProxyPrefix:      *fileProxyPrefix,
+		SlackDebug: *flagSlackDebug,
 	}
 	if err := server.Start(); err != nil {
 		log.Fatal(err)

--- a/server.go
+++ b/server.go
@@ -16,7 +16,7 @@ type Server struct {
 	LocalAddr            net.Addr
 	Listener             *net.TCPListener
 	SlackAPIKey          string
-	SlackDebug bool
+	SlackDebug           bool
 	ChunkSize            int
 	FileDownloadLocation string
 	FileProxyPrefix      string
@@ -105,7 +105,7 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 			Conn:              conn,
 			ServerName:        s.Name,
 			SlackAPIKey:       s.SlackAPIKey,
-			SlackDebug: s.SlackDebug,
+			SlackDebug:        s.SlackDebug,
 			ChunkSize:         s.ChunkSize,
 			postMessage:       make(chan SlackPostMessage),
 			conversationCache: make(map[string]*slack.Channel),

--- a/server.go
+++ b/server.go
@@ -16,6 +16,7 @@ type Server struct {
 	LocalAddr            net.Addr
 	Listener             *net.TCPListener
 	SlackAPIKey          string
+	SlackDebug bool
 	ChunkSize            int
 	FileDownloadLocation string
 	FileProxyPrefix      string
@@ -104,6 +105,7 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 			Conn:              conn,
 			ServerName:        s.Name,
 			SlackAPIKey:       s.SlackAPIKey,
+			SlackDebug: s.SlackDebug,
 			ChunkSize:         s.ChunkSize,
 			postMessage:       make(chan SlackPostMessage),
 			conversationCache: make(map[string]*slack.Channel),


### PR DESCRIPTION
Using the flag -D will print debugging output from the Slack API.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>