### PR TITLE
Better logging for Slack API debug logs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
 github.com/go-toolsmith/astcopy v1.0.0/go.mod h1:vrgyG+5Bxrnz4MZWPF+pI4R8h3qKRjjyvV/DSez4WVQ=

--- a/irc_server.go
+++ b/irc_server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
+	"github.com/coredhcp/coredhcp/logger"
 )
 
 // Project constants
@@ -416,10 +417,9 @@ func IrcPrivMsgHandler(ctx *IrcContext, prefix, cmd string, args []string, trail
 		getTargetTs(channelParameter),
 	)
 }
-
 // wrapped logger that satisfies the slack.logger interface
 type loggerWrapper struct {
-	*logrus.Logger
+	*logrus.Entry
 }
 
 func (l *loggerWrapper) Output(calldepth int, s string) error {
@@ -431,7 +431,7 @@ func connectToSlack(ctx *IrcContext) error {
 	ctx.SlackClient = slack.New(
 		ctx.SlackAPIKey,
 		slack.OptionDebug(ctx.SlackDebug),
-		slack.OptionLog(&loggerWrapper{log.Logger}),
+		slack.OptionLog(&loggerWrapper{logger.GetLogger("slack-api")}),
 	)
 	rtm := ctx.SlackClient.NewRTM()
 	ctx.SlackRTM = rtm


### PR DESCRIPTION
Now Slack API debug logs are prefixed with "slack-api"

Signed-off-by: Andrea Barberio <insomniac@slackware.it>