### PR TITLE
Support Oauth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ go build
 
 Then configure your IRC client to connect to localhost:6666 and use a Slack legacy token as password. Get you Slack legacy token at https://api.slack.com/custom-integrations/legacy-tokens .
 
+Slack has announced that they will stop issuing legacy tokens starting the 4th
+of may 2020. As an alternative, you can install the irc-slack app, and get the token returned after you authorize it. The token starts with `xoxp-`.
+This is a Slack app with full user permissions, that is used to generate a Slack user token.
+
+Click on the button below to install the app:
+
+[![Authorize irc-slack](https://platform.slack-edge.com/img/add_to_slack.png)](https://slack.com/oauth/authorize?client_id=152572391990.1078733520672&scope=client)
+
+Then copy the token from the resulting page (it starts with `xoxp-`).
+
+This app exchanges your temporary authentication code with a permanent token.
+While the app does not log your token, you may rightfully not trust it or want
+to run your own. In order to do so, you need the two following steps:
+* create a Slack app using their v1 OauthV2 API (note: not their v2 version) at https://api.slack.com/apps
+* configure the redirect URL to your endpoint (in this case
+  https://my-server/irc-slack/auth/)
+* run the web app under [slackapp](slackapp/) passing your app client ID and client secret, you can find them in the Basic Information tab at the link at the previous step
+
+
 ## Run it with Docker
 
 Thanks to [halkeye](https://github.com/halkeye) you can run `irc-slack` via

--- a/slackapp/main.go
+++ b/slackapp/main.go
@@ -1,0 +1,139 @@
+package main
+
+/* Slack Oauth app built according to
+ * https://api.slack.com/authentication/oauth-v2
+ */
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// irc-slack app client ID, see https://api.slack.com/apps/
+	clientID     = os.Getenv("SLACK_APP_CLIENT_ID")
+	clientSecret = os.Getenv("SLACK_APP_CLIENT_SECRET")
+)
+
+func httpStatus(w http.ResponseWriter, r *http.Request, statusCode int, fmtstr string, args ...interface{}) {
+	w.WriteHeader(statusCode)
+	msg := fmt.Sprintf(fmtstr, args...)
+	fullmsg := fmt.Sprintf("%d - %s\n%s", statusCode, http.StatusText(statusCode), msg)
+	if _, err := w.Write([]byte(fullmsg)); err != nil {
+		log.Warningf("Cannot write response: %v", err)
+	}
+}
+
+type slackChallenge struct {
+	Token, Challenge, Type string
+}
+
+func handleSlackChallenge(w http.ResponseWriter, r *http.Request) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Infof("Cannot read body: %v", err)
+		httpStatus(w, r, 500, "")
+		return
+	}
+	var sc slackChallenge
+	if err := json.Unmarshal(data, &sc); err != nil {
+		log.Infof("Cannot unmarshal JSON: %v", err)
+		httpStatus(w, r, 400, "")
+		return
+	}
+	if _, err := w.Write([]byte(sc.Challenge)); err != nil {
+		log.Warningf("Failed to write response: %v", err)
+	}
+}
+
+func handleSlackAuth(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query()["code"]
+	if len(code) < 1 {
+		log.Info("Missing \"code\" parameter in request")
+		httpStatus(w, r, 400, "")
+		return
+	}
+	// get token from Slack
+	form := url.Values{}
+	form.Add("code", code[0])
+	form.Add("client_id", clientID)
+	form.Add("client_secret", clientSecret)
+	accessURL := "https://slack.com/api/oauth.access"
+
+	client := http.Client{}
+	req, err := http.NewRequest("POST", accessURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		log.Infof("Failed to build request for Slack auth API: %v", err)
+		httpStatus(w, r, 500, "")
+		return
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Infof("Failed to request token to Slack auth API: %v", err)
+		httpStatus(w, r, 500, "")
+		return
+	}
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Infof("Failed to read body from Slack auth API response: %v", err)
+		httpStatus(w, r, 500, "")
+		return
+	}
+	// parse the response message
+	// Documented at https://api.slack.com/methods/oauth.access .
+	// There are other fields, but we don't care about them here.
+	type authmsg struct {
+		Ok           bool    `json:"ok"`
+		Error        string  `json:"error"`
+		AccessToken  string  `json:"access_token"`
+		TeamName     string  `json:"team_name"`
+		TeamID       string  `json:"team_id"`
+		Scope        string  `json:"scope"`
+		EnterpriseID *string `json:"enterprise_id,omitempty"`
+	}
+	var msg authmsg
+	if err := json.Unmarshal(data, &msg); err != nil {
+		log.Infof("Failed to unmarshal API response response: %v", err)
+		httpStatus(w, r, 500, "")
+	}
+	if !msg.Ok {
+		log.Infof("Got error response from auth API: %s", msg.Error)
+		httpStatus(w, r, 500, "")
+		return
+	}
+	indented, err := json.MarshalIndent(msg, "", "    ")
+	if err != nil {
+		log.Infof("Cannot re-marshal API response with indentation: %v", err)
+		httpStatus(w, r, 500, "")
+		return
+	}
+	httpStatus(w, r, 200, string(indented))
+}
+
+func main() {
+	flag.Parse()
+	addr := ":2020"
+	if flag.Arg(0) != "" {
+		addr = flag.Arg(0)
+	}
+	if clientID == "" {
+		log.Fatalf("SLACK_APP_CLIENT_ID is empty or not set")
+	}
+	if clientSecret == "" {
+		log.Fatalf("SLACK_APP_CLIENT_SECRET is empty or not set")
+	}
+	http.HandleFunc("/irc-slack/challenge/", handleSlackChallenge)
+	http.HandleFunc("/irc-slack/auth/", handleSlackAuth)
+	log.Printf("Listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}


### PR DESCRIPTION
Added instructions and app code to use Oauth token instead of legacy
tokens, since Slack will soon remove support for the latter.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>