### PR TITLE
Updated CI to use Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 go:
-  - "1.12"
-  - "1.13beta1"
+  - "1.13.x"
+  - "1.14.x"
   - tip
 
 before_install:


### PR DESCRIPTION
Also dropping Go 1.12, let's only support the last two versions.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>