### PR TITLE
Add pagination flag

### DIFF
--- a/irc_server.go
+++ b/irc_server.go
@@ -439,7 +439,7 @@ type httpClient struct {
 
 func (hc httpClient) Do(req *http.Request) (*http.Response, error) {
 	if hc.cookie != "" {
-		log.Infof("Setting auth cookie")
+		log.Debugf("Setting auth cookie")
 		if strings.ToLower(req.URL.Scheme) == "https" {
 			req.Header.Add("Cookie", hc.cookie)
 		} else {

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	fileProxyPrefix      = flag.String("l", "", "If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d")
 	logLevel             = flag.String("L", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
 	flagSlackDebug       = flag.Bool("D", false, "Enable debug logging of the Slack API")
+	flagPagination       = flag.Int("P", 0, "Pagination value for API calls. If 0 or unspecified, use the recommended default (currently 200). Larger values can help on large Slack teams")
 )
 
 var log = logger.GetLogger("main")
@@ -87,6 +88,7 @@ func main() {
 		FileDownloadLocation: *fileDownloadLocation,
 		FileProxyPrefix:      *fileProxyPrefix,
 		SlackDebug:           *flagSlackDebug,
+		Pagination:           *flagPagination,
 	}
 	if err := server.Start(); err != nil {
 		log.Fatal(err)

--- a/server.go
+++ b/server.go
@@ -20,6 +20,7 @@ type Server struct {
 	ChunkSize            int
 	FileDownloadLocation string
 	FileProxyPrefix      string
+	Pagination           int
 }
 
 // Start runs the IRC server
@@ -114,6 +115,7 @@ func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
 				FileDownloadLocation: s.FileDownloadLocation,
 				ProxyPrefix:          s.FileProxyPrefix,
 			},
+			Pagination: s.Pagination,
 		}
 		go ctx.Start()
 		UserContexts[conn.RemoteAddr()] = ctx


### PR DESCRIPTION
Using -P on the command line it's not possible to increase the
pagination size for Slack users.list requests. Larger values help
connecting faster on large Slack teams.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>