### PR TITLE
Remove debug log of HTTP request

### DIFF
--- a/irc_server.go
+++ b/irc_server.go
@@ -446,7 +446,6 @@ func (hc httpClient) Do(req *http.Request) (*http.Response, error) {
 			log.Warning("Cookie is set but connection is not HTTPS, skipping")
 		}
 	}
-	log.Debugf("HTTP request: %+v", req)
 	return hc.c.Do(req)
 }
 


### PR DESCRIPTION
I introduced this a couple of commits ago. It could disclose the auth
cookie, if the user sets it, so I am removing it.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>