### PR TITLE
Hide PASS arguments

### DIFF
--- a/irc_server.go
+++ b/irc_server.go
@@ -603,7 +603,7 @@ func IrcModeHandler(ctx *IrcContext, prefix, cmd string, args []string, trailing
 // IrcPassHandler is called when a PASS command is sent
 func IrcPassHandler(ctx *IrcContext, prefix, cmd string, args []string, trailing string) {
 	if len(args) != 1 {
-		log.Warningf("Invalid PASS arguments: %s", args)
+		log.Warningf("Invalid PASS arguments. Arguments are not shown for this method because they may contain Slack tokens or cookies")
 		// ERR_PASSWDMISMATCH
 		if err := SendIrcNumeric(ctx, 464, "", "Invalid password"); err != nil {
 			log.Warningf("Failed to send IRC message: %v", err)

--- a/server.go
+++ b/server.go
@@ -63,7 +63,11 @@ func (s Server) HandleRequest(conn *net.TCPConn) {
 
 // HandleMsg handles raw IRC messages
 func (s *Server) HandleMsg(conn *net.TCPConn, msg string) {
-	log.Debugf("%v: %v", conn.RemoteAddr(), msg)
+	if strings.HasPrefix(msg, "PASS ") {
+		log.Debugf("%v: PASS ***** (redacted for privacy)", conn.RemoteAddr())
+	} else {
+		log.Debugf("%v: %v", conn.RemoteAddr(), msg)
+	}
 	if len(msg) < 1 {
 		log.Warningf("Invalid message: '%v'", msg)
 		return


### PR DESCRIPTION
Fixes #6 

PASS commands can contain sensitive information. This commit hides such
content from the logs.

Example run after applying this patch:
```
$ go run . -D -L debug -P 1000
[2020-05-04T12:19:23+01:00]  INFO main: Setting log level to 'debug'
[2020-05-04T12:19:23+01:00]  INFO main: Starting server on 127.0.0.1:6666
[2020-05-04T12:19:23+01:00]  INFO main: Listening on 127.0.0.1:6666
[2020-05-04T12:19:24+01:00] DEBUG [github.com/sirupsen/logrus.(*Entry).Debugf][entry.go][344] main: 127.0.0.1:40058: CAP LS

[2020-05-04T12:19:24+01:00] DEBUG [github.com/sirupsen/logrus.(*Entry).Debugf][entry.go][344] main: 127.0.0.1:40058: PASS ***** (redacted for privacy)
[2020-05-04T12:19:24+01:00] DEBUG [github.com/sirupsen/logrus.(*Entry).Debugf][entry.go][344] main: 127.0.0.1:40058: NICK insomniac

[2020-05-04T12:19:24+01:00]  INFO main: Starting Slack client
```

Signed-off-by: Andrea Barberio <insomniac@slackware.it>