### PR TITLE
Change nick immediately on slack connect

### DIFF
--- a/irc_context.go
+++ b/irc_context.go
@@ -24,6 +24,7 @@ type IrcContext struct {
 	User *slack.User
 	// TODO make RealName a function
 	RealName          string
+	OrigName          string
 	SlackClient       *slack.Client
 	SlackRTM          *slack.RTM
 	SlackAPIKey       string


### PR DESCRIPTION
If we wish to use the slack nickname in client communication, we must
first change the nick from the original submitted nick to the slack
nickname. Otherwise, if the slack nickname does not happen to match the
client-specified nickname, we just end up with wrong sources and
destinations for messages.

Store the original nickname for use in the rename process, reorder the
connect logic slightly to occur once we have all three needed
parameters, and make it so that the nickname is changed after slack
connect if it does not match the client specified one.