### PR TITLE
Refactoring: first step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 coverage.txt
-irc-slack
+cmd/irc-slack/irc-slack

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ FROM golang:1.12-alpine AS builder
 RUN apk update && apk add --no-cache git
 COPY . $GOPATH/src/insomniacslk/irc-slack
 ENV GO111MODULE=on
-WORKDIR $GOPATH/src/insomniacslk/irc-slack
-# Fetch dependencies.
-# Using go get.
-RUN go get -d -v
+WORKDIR $GOPATH/src/insomniacslk/irc-slack/cmd/irc-slack
 # Build the binary.
 RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/irc-slack
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ what's left to do for people like me, who want to still be able to log in via
 IRC? Either you use [wee-slack](https://github.com/wee-slack/wee-slack) (~~but I
 don't use WeeChat~~), or you implement your own stuff.
 
-The code quality is currently at the `works-for-me` level, but it's improving steadily.
-
 NOTE: after Slack turned down their IRC gateway I got a lot of contacts from users of irc-slack asking me to fix and improve it. I didn't expect people to actually use it, but thanks to your feedback I'm now actively developing it again :-)
 Please keep reporting bugs and sending PRs!
 
 ## How to use it
 
 ```
-go get ./...  # download the dependencies, currently just github.com/slack-go/slack
+cd cmd/irc-slack
 go build
 ./irc-slack # by default on port 6666
 ```
@@ -70,10 +68,16 @@ TLS on `irc-slack`, and enable TLS on your IRC client.
 ### User tokens with auth cookie
 
 This approach does not require legacy tokens nor installing any app, but in order to
-get the token there are a few manual steps to execute in your browser's console.
+get the token there are a few manual steps to execute.
 
 This type of token starts with `xoxc-`, and requires an auth cookie to be paired
 to it in order to work.
+
+There are two possible procedures, an entirely manual one, using the browser
+console, and a semi-automated one, which requires Chrome or Chromium in headless
+mode.
+
+**manual procedure via browser**
 
 This is the same procedure as described in two similar projects, see:
 * https://github.com/adsr/irslackd/wiki/IRC-Client-Config#xoxc-tokens
@@ -91,7 +95,10 @@ xoxc-XXXX|d=XXXX;
 
 and use the above as your IRC password.
 
-Alternatively, you can try [autotoken](tools/autotoken).
+**semi-automated procedure using Chrome/Chromium in headless mode**
+
+See [autotoken](tools/autotoken). Just build it with `go build` and run with
+`./autotoken -h` to see the usage help.
 
 ### Slack App tokens
 

--- a/cmd/irc-slack/main.go
+++ b/cmd/irc-slack/main.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 
+	"github.com/insomniacslk/irc-slack/pkg/ircslack"
+
 	"github.com/coredhcp/coredhcp/logger"
 	"github.com/sirupsen/logrus"
 )
@@ -99,7 +101,7 @@ func main() {
 		}
 		tlsConfig = &tls.Config{Certificates: []tls.Certificate{cert}}
 	}
-	server := Server{
+	server := ircslack.Server{
 		LocalAddr:            &localAddr,
 		Name:                 sName,
 		ChunkSize:            *chunkSize,

--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,4 @@ require (
 	golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa // indirect
 )
 
-go 1.13
+go 1.14

--- a/pkg/ircslack/event_handler.go
+++ b/pkg/ircslack/event_handler.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"fmt"

--- a/pkg/ircslack/file_handler.go
+++ b/pkg/ircslack/file_handler.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"fmt"

--- a/pkg/ircslack/irc_channel.go
+++ b/pkg/ircslack/irc_channel.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 // Channel represents an IRC channel. It maps to Slack's groups and channels.
 // Private messages are handled differently.

--- a/pkg/ircslack/irc_channel_test.go
+++ b/pkg/ircslack/irc_channel_test.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"testing"

--- a/pkg/ircslack/irc_context.go
+++ b/pkg/ircslack/irc_context.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"fmt"

--- a/pkg/ircslack/irc_server.go
+++ b/pkg/ircslack/irc_server.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"errors"

--- a/pkg/ircslack/logger.go
+++ b/pkg/ircslack/logger.go
@@ -1,0 +1,5 @@
+package ircslack
+
+import "github.com/coredhcp/coredhcp/logger"
+
+var log = logger.GetLogger("ircslack")

--- a/pkg/ircslack/server.go
+++ b/pkg/ircslack/server.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"bufio"

--- a/pkg/ircslack/users.go
+++ b/pkg/ircslack/users.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"context"

--- a/pkg/ircslack/users_test.go
+++ b/pkg/ircslack/users_test.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"bytes"

--- a/pkg/ircslack/wordwrap.go
+++ b/pkg/ircslack/wordwrap.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"strings"

--- a/pkg/ircslack/wordwrap_test.go
+++ b/pkg/ircslack/wordwrap_test.go
@@ -1,4 +1,4 @@
-package main
+package ircslack
 
 import (
 	"strings"


### PR DESCRIPTION
First step to refactor irc-slack in a set of packages and commands.
The new structure has one big library `pkg/ircslack` and the command
line tool, `cmd/irc-slack`.
In future commits, the library will be further splitted and cleaned up.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>