### PR TITLE
Use spf13/pflag for command line parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,23 +182,19 @@ There are a few options that you can pass to the server, e.g. to change the list
 ```
 $ ./irc-slack -h
 Usage of ./irc-slack:
-  -D    Enable debug logging of the Slack API
-  -H string
-        IP address to listen on (default "127.0.0.1")
-  -L string
-        Log level. One of [debug info warning error fatal none] (default "info")
-  -P int
-        Pagination value for API calls. If 0 or unspecified, use the recommended default (currently 200). Larger values can help on large Slack teams
-  -chunk int
-        Maximum size of a line to send to the client. Only works for certain reply types (default 512)
-  -d string
-        If set will download attachments to this location
-  -l string
-        If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d
-  -p int
-        Local port to listen on (default 6666)
-  -s string
-        IRC server name (i.e. the host name to send to clients)
+  -c, --cert string         TLS certificate for HTTPS server. Requires -key
+  -C, --chunk int           Maximum size of a line to send to the client. Only works for certain reply types (default 512)
+  -D, --debug               Enable debug logging of the Slack API
+  -d, --download string     If set will download attachments to this location
+  -l, --fileprefix string   If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d
+  -H, --host string         IP address to listen on (default "127.0.0.1")
+  -k, --key string          TLS key for HTTPS server. Requires -cert
+  -L, --loglevel string     Log level. One of [none debug info warning error fatal] (default "info")
+  -P, --pagination int      Pagination value for API calls. If 0 or unspecified, use the recommended default (currently 200). Larger values can help on large Slack teams
+  -p, --port int            Local port to listen on (default 6666)
+  -s, --server string       IRC server name (i.e. the host name to send to clients)
+pflag: help requested
+exit status 2
 ```
 
 ## Deploying with Puppet

--- a/cmd/irc-slack/main.go
+++ b/cmd/irc-slack/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -12,31 +11,23 @@ import (
 
 	"github.com/coredhcp/coredhcp/logger"
 	"github.com/sirupsen/logrus"
+	flag "github.com/spf13/pflag"
 )
 
-// TODO handle expired Slack RTM sessions (e.g. after standby/resume)
-// TODO better handling of QUIT
-// TODO handle channel/user MODE. Set it to +s on Slack groups (private channels)
-// TODO handle /me with the me_message subtype
-// TODO handle INVITE - InviteUserToChannel
-// TODO handle KICK - KickUserFromChannel
-// TODO handle return value from IrcSendNumeric
-
 // To authenticate, the IRC client has to send a PASS command with a Slack
-// legacy token for the desired team. See
-// https://api.slack.com/custom-integrations/legacy-tokens
+// legacy token for the desired team. See README.md for details.
 var (
-	port                 = flag.Int("p", 6666, "Local port to listen on")
-	host                 = flag.String("H", "127.0.0.1", "IP address to listen on")
-	serverName           = flag.String("s", "", "IRC server name (i.e. the host name to send to clients)")
-	chunkSize            = flag.Int("chunk", 512, "Maximum size of a line to send to the client. Only works for certain reply types")
-	fileDownloadLocation = flag.String("d", "", "If set will download attachments to this location")
-	fileProxyPrefix      = flag.String("l", "", "If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d")
-	logLevel             = flag.String("L", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
-	flagSlackDebug       = flag.Bool("D", false, "Enable debug logging of the Slack API")
-	flagPagination       = flag.Int("P", 0, "Pagination value for API calls. If 0 or unspecified, use the recommended default (currently 200). Larger values can help on large Slack teams")
-	flagKey              = flag.String("key", "", "TLS key for HTTPS server. Requires -cert")
-	flagCert             = flag.String("cert", "", "TLS certificate for HTTPS server. Requires -key")
+	port                 = flag.IntP("port", "p", 6666, "Local port to listen on")
+	host                 = flag.StringP("host", "H", "127.0.0.1", "IP address to listen on")
+	serverName           = flag.StringP("server", "s", "", "IRC server name (i.e. the host name to send to clients)")
+	chunkSize            = flag.IntP("chunk", "C", 512, "Maximum size of a line to send to the client. Only works for certain reply types")
+	fileDownloadLocation = flag.StringP("download", "d", "", "If set will download attachments to this location")
+	fileProxyPrefix      = flag.StringP("fileprefix", "l", "", "If set will overwrite urls to attachments with this prefix and local file name inside the path set with -d")
+	logLevel             = flag.StringP("loglevel", "L", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
+	flagSlackDebug       = flag.BoolP("debug", "D", false, "Enable debug logging of the Slack API")
+	flagPagination       = flag.IntP("pagination", "P", 0, "Pagination value for API calls. If 0 or unspecified, use the recommended default (currently 200). Larger values can help on large Slack teams")
+	flagKey              = flag.StringP("key", "k", "", "TLS key for HTTPS server. Requires -cert")
+	flagCert             = flag.StringP("cert", "c", "", "TLS certificate for HTTPS server. Requires -key")
 )
 
 var log = logger.GetLogger("main")

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.5.0
 	github.com/slack-go/slack v0.6.3
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
 	golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=


### PR DESCRIPTION
This provides a more flexible syntax, with long and short options.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>