### PR TITLE
Send supported CHANTYPES to client

### DIFF
--- a/pkg/ircslack/irc_server.go
+++ b/pkg/ircslack/irc_server.go
@@ -303,6 +303,10 @@ func IrcAfterLoggingIn(ctx *IrcContext, rtm *slack.RTM) error {
 			log.Warningf("Failed to send IRC message: %v", err)
 		}
 	}
+	// RPL_ISUPPORT
+	if err := SendIrcNumeric(ctx, 005, ctx.Nick(), "CHANTYPES=#+&"); err != nil {
+		log.Warningf("Failed to send IRC message: %v", err)
+	}
 	motd(fmt.Sprintf("This is an IRC-to-Slack gateway, written by %s <%s>.", ProjectAuthor, ProjectAuthorEmail))
 	motd(fmt.Sprintf("More information at %s.", ProjectURL))
 	motd(fmt.Sprintf("Slack team name: %s", ctx.SlackRTM.GetInfo().Team.Name))


### PR DESCRIPTION
Makes sure the clients are aware of the types we support. Noticed this after weechat changed it's default chantypes for servers that don't report it: https://github.com/weechat/weechat/commit/4a42cda3a5f5b02d8ba9afae129499c26250d334