### PR TITLE
Export PATH in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@
 FROM golang:1.12-alpine AS builder
 
 LABEL BUILD="docker build -t insomniacslk/irc-slack -f Dockerfile ."
-LABEL RUN="docker run --rm -it insomniacslk/irc-slack"
+LABEL RUN="docker run --rm -p 6666:6666 -it insomniacslk/irc-slack"
 
 # Install git.
 # Git is required for fetching the dependencies.
-RUN apk update && apk add --no-cache git
+RUN apk update && apk add --no-cache git bash
 COPY . $GOPATH/src/insomniacslk/irc-slack
 ENV GO111MODULE=on
 WORKDIR $GOPATH/src/insomniacslk/irc-slack/cmd/irc-slack
@@ -23,5 +23,6 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 # Copy our static executable.
 COPY --from=builder /go/bin/irc-slack /go/bin/irc-slack
+ENV PATH="/go/bin:$PATH"
 # Run the irc-slack binary.
 CMD ["/go/bin/irc-slack", "-H", "0.0.0.0"]


### PR DESCRIPTION
So you can call irc-slack without absolute path if you want to override
the command line

Signed-off-by: Andrea Barberio <insomniac@slackware.it>