### PR TITLE
Do not sort command line flags

### DIFF
--- a/cmd/irc-slack/main.go
+++ b/cmd/irc-slack/main.go
@@ -58,6 +58,7 @@ func getLogLevels() []string {
 }
 
 func main() {
+	flag.CommandLine.SortFlags = false
 	flag.Parse()
 	if *flagVersion {
 		fmt.Printf("%s version %s\n", ProgramName, Version)


### PR DESCRIPTION
pflag by default sorts the command line flags. In irc-slack some flags
are related and should be shown together, which is possible by removing
flag sorting.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>