### PR TITLE
Do not print message if hidden

### DIFF
--- a/pkg/ircslack/event_handler.go
+++ b/pkg/ircslack/event_handler.go
@@ -285,6 +285,9 @@ func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 		case *slack.MessageEvent:
 			// https://api.slack.com/events/message
 			message := ev.Msg
+			if message.Hidden {
+				continue
+			}
 			switch message.SubType {
 			case "message_changed":
 				// https://api.slack.com/events/message/message_changed


### PR DESCRIPTION
Slack can send "hidden" messages, that are not part of the conversation.
When the hidden flag is set, we don't print them anymore.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>