### PR TITLE
[tools/autotoken] Ensure defers are called

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
-	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
+	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 )
 
 go 1.14


### PR DESCRIPTION
Due to the use of log.Fatalf it was possible for defers not to run in
case of errors, which had the consequence of leaving headless chrome
instancess running in background even after completion.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>