### PR TITLE
Removed IrcContext.GetUsers

### DIFF
--- a/pkg/ircslack/event_handler.go
+++ b/pkg/ircslack/event_handler.go
@@ -344,7 +344,9 @@ func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 			// https://api.slack.com/events/user_change
 			// Refresh the users list
 			// TODO update just the new user
-			ctx.GetUsers(true)
+			if err := ctx.Users.Fetch(ctx.SlackClient); err != nil {
+				log.Warningf("Failed to fetch users: %v", err)
+			}
 		case *slack.ChannelJoinedEvent:
 			// https://api.slack.com/events/channel_joined
 			if _, err := ctx.Conn.Write([]byte(fmt.Sprintf(":%v JOIN #%v\r\n", ctx.Mask(), ev.Channel.Name))); err != nil {

--- a/pkg/ircslack/irc_context.go
+++ b/pkg/ircslack/irc_context.go
@@ -58,18 +58,6 @@ func (ic *IrcContext) UserName() string {
 	return ic.User.ID
 }
 
-// GetUsers returns a list of users of the Slack team the context is connected
-// to
-func (ic *IrcContext) GetUsers(refresh bool) *Users {
-	if refresh || ic.Users == nil || ic.Users.Count() == 0 {
-		if err := ic.Users.Fetch(ic.SlackClient); err != nil {
-			// if fetching failed, do not modify the existing users object
-			log.Warningf("Failed to fetch users: %v", err)
-		}
-	}
-	return ic.Users
-}
-
 // GetThreadOpener returns text of the first message in a thread that provided message belongs to
 func (ic *IrcContext) GetThreadOpener(channel string, threadTimestamp string) (slack.Message, error) {
 	msgs, _, _, err := ic.SlackClient.GetConversationReplies(&slack.GetConversationRepliesParameters{


### PR DESCRIPTION
This function is redundant. Used Users.Fetch directly instead.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>