### PR TITLE
Introduced Channels struct

### DIFF
--- a/pkg/ircslack/channels.go
+++ b/pkg/ircslack/channels.go
@@ -1,0 +1,113 @@
+package ircslack
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// Channels wraps the channel list with convenient operations and cache.
+type Channels struct {
+	channels map[string]slack.Channel
+	mu       sync.Mutex
+}
+
+// NewChannels creates a new Channels object.
+func NewChannels() *Channels {
+	return &Channels{
+		channels: make(map[string]slack.Channel),
+	}
+}
+
+// AsMap returns the channels as a map of name -> channel. The map is copied to
+// avoid data races
+func (c *Channels) AsMap() map[string]slack.Channel {
+	var ret map[string]slack.Channel
+	for k, v := range c.channels {
+		ret[k] = v
+	}
+	return ret
+}
+
+// Fetch retrieves all the channels on a given Slack team. The Slack client has
+// to be valid and connected.
+func (c *Channels) Fetch(client *slack.Client) error {
+	log.Infof("Fetching all channels, might take a while on large Slack teams")
+	// currently slack-go does not expose a way to change channel pagination as
+	// it does for the users API.
+	var (
+		err      error
+		ctx      = context.Background()
+		channels = make(map[string]slack.Channel)
+	)
+	start := time.Now()
+	params := slack.GetConversationsParameters{
+		Limit: 100,
+	}
+	for err == nil {
+		chans, nextCursor, err := client.GetConversationsContext(ctx, &params)
+		if err == nil {
+			log.Debugf("Retrieved %d channels (current total is %d)", len(chans), len(channels))
+			for _, c := range chans {
+				// WARNING WARNING WARNING: channels are internally mapped by
+				// name, while users are mapped by ID.
+				channels[c.Name] = c
+			}
+		} else if rateLimitedError, ok := err.(*slack.RateLimitedError); ok {
+			select {
+			case <-ctx.Done():
+				err = ctx.Err()
+			case <-time.After(rateLimitedError.RetryAfter):
+				err = nil
+			}
+		}
+		if nextCursor == "" {
+			break
+		}
+		params.Cursor = nextCursor
+	}
+	log.Infof("Retrieved %d channels in %s", len(channels), time.Since(start))
+	c.mu.Lock()
+	c.channels = channels
+	for name, ch := range channels {
+		log.Debugf("Retrieved channel: %s -> %+v", name, ch)
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+// Count returns the number of channels. This method must be called after
+// `Fetch`.
+func (c *Channels) Count() int {
+	return len(c.channels)
+}
+
+// ByID retrieves a channel by its Slack ID.
+func (c *Channels) ByID(id string) *slack.Channel {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, c := range c.channels {
+		if c.ID == id {
+			return &c
+		}
+	}
+	return nil
+}
+
+// ByName retrieves a channel by its Slack name.
+func (c *Channels) ByName(name string) *slack.Channel {
+	if strings.HasPrefix(name, "#") {
+		name = name[1:]
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, c := range c.channels {
+		if c.Name == name {
+			return &c
+		}
+	}
+	return nil
+}

--- a/pkg/ircslack/channels_test.go
+++ b/pkg/ircslack/channels_test.go
@@ -1,0 +1,80 @@
+package ircslack
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelsNewChannels(t *testing.T) {
+	u := NewChannels()
+	require.NotNil(t, u)
+	assert.NotNil(t, u.channels)
+}
+
+type fakeErrorChannelsPaginationComplete struct{}
+
+type fakeChannelsResponse struct {
+	Members []slack.Channel
+	Channel slack.Channel
+}
+
+func (f fakeErrorChannelsPaginationComplete) Error() string {
+	return "pagination complete"
+}
+
+type fakeSlackHTTPClientChannels struct{}
+
+func (c fakeSlackHTTPClientChannels) Do(req *http.Request) (*http.Response, error) {
+	switch req.URL.Path {
+	case "/api/conversations.list":
+		// reply as per https://api.slack.com/methods/channels.list
+		data := []byte(`{"channels": [{"id": "1234", "name": "general", "is_channel": true}], "response_metadata": {"next_cursor": ""}}`)
+		return &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(data)),
+		}, nil
+	default:
+		return nil, fmt.Errorf("testing: http client URL not supported: %s", req.URL)
+	}
+}
+
+func TestChannelsFetch(t *testing.T) {
+	client := slack.New("test-token", slack.OptionHTTPClient(fakeSlackHTTPClientChannels{}))
+	channels := NewChannels()
+	err := channels.Fetch(client)
+	require.NoError(t, err)
+	assert.Equal(t, 1, channels.Count())
+}
+
+func TestChannelsById(t *testing.T) {
+	client := slack.New("test-token", slack.OptionHTTPClient(fakeSlackHTTPClientChannels{}))
+	channels := NewChannels()
+	err := channels.Fetch(client)
+	require.NoError(t, err)
+	u := channels.ByID("1234")
+	require.NotNil(t, u)
+	assert.Equal(t, "1234", u.ID)
+	assert.Equal(t, "general", u.Name)
+}
+
+func TestChannelsByName(t *testing.T) {
+	client := slack.New("test-token", slack.OptionHTTPClient(fakeSlackHTTPClientChannels{}))
+	channels := NewChannels()
+	err := channels.Fetch(client)
+	require.NoError(t, err)
+	u := channels.ByName("general")
+	require.NotNil(t, u)
+	assert.Equal(t, "1234", u.ID)
+	assert.Equal(t, "general", u.Name)
+}

--- a/pkg/ircslack/event_handler.go
+++ b/pkg/ircslack/event_handler.go
@@ -43,8 +43,7 @@ func resolveChannelName(ctx *IrcContext, msgChannel, threadTimestamp string) str
 			return ""
 		} else if threadTimestamp != "" {
 			channame := formatThreadChannelName(threadTimestamp, channel)
-			_, ok := ctx.Channels[channame]
-			if !ok {
+			if ctx.Channels.ByName(channame) == nil {
 				openingText, err := ctx.GetThreadOpener(msgChannel, threadTimestamp)
 				if err == nil {
 					IrcSendChanInfoAfterJoin(
@@ -79,8 +78,7 @@ func resolveChannelName(ctx *IrcContext, msgChannel, threadTimestamp string) str
 			return channame
 		} else if channel.IsMpIM {
 			channame := formatMultipartyChannelName(msgChannel, channel.Name)
-			_, ok := ctx.Channels[channame]
-			if !ok {
+			if ctx.Channels.ByName(channame) == nil {
 				IrcSendChanInfoAfterJoin(
 					ctx,
 					channame,

--- a/pkg/ircslack/irc_context.go
+++ b/pkg/ircslack/irc_context.go
@@ -30,7 +30,7 @@ type IrcContext struct {
 	SlackDebug        bool
 	SlackConnected    bool
 	ServerName        string
-	Channels          map[string]Channel
+	Channels          *Channels
 	ChanMutex         *sync.Mutex
 	Users             *Users
 	ChunkSize         int

--- a/pkg/ircslack/server.go
+++ b/pkg/ircslack/server.go
@@ -125,7 +125,8 @@ func (s *Server) HandleMsg(conn net.Conn, msg string) {
 				FileDownloadLocation: s.FileDownloadLocation,
 				ProxyPrefix:          s.FileProxyPrefix,
 			},
-			Users: NewUsers(s.Pagination),
+			Users:    NewUsers(s.Pagination),
+			Channels: NewChannels(),
 		}
 		go ctx.Start()
 		UserContexts[conn.RemoteAddr()] = ctx

--- a/pkg/ircslack/users.go
+++ b/pkg/ircslack/users.go
@@ -15,7 +15,7 @@ type Users struct {
 	pagination int
 }
 
-// NewUsers creates a new Users object
+// NewUsers creates a new Users object.
 func NewUsers(pagination int) *Users {
 	return &Users{
 		users:      make(map[string]slack.User),


### PR DESCRIPTION
Simplifies channel handling, and will enable optimizations to avoid
fetching all the users at connection time, which is very slow on large
Slack teams.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>