### PR TITLE
Clear IRC context on disconnect

### DIFF
--- a/pkg/ircslack/event_handler.go
+++ b/pkg/ircslack/event_handler.go
@@ -327,6 +327,7 @@ func eventHandler(ctx *IrcContext, rtm *slack.RTM) {
 			log.Warningf("Disconnected from Slack (intentional: %v, cause: %v)", de.Intentional, de.Cause)
 			ctx.SlackConnected = false
 			ctx.Conn.Close()
+			ctx.Users, ctx.Channels = nil, nil
 			return
 		case *slack.MemberJoinedChannelEvent:
 			// This is the currently preferred way to notify when a user joins a

--- a/pkg/ircslack/irc_context.go
+++ b/pkg/ircslack/irc_context.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/slack-go/slack"
@@ -31,7 +30,6 @@ type IrcContext struct {
 	SlackConnected    bool
 	ServerName        string
 	Channels          *Channels
-	ChanMutex         *sync.Mutex
 	Users             *Users
 	ChunkSize         int
 	postMessage       chan SlackPostMessage

--- a/pkg/ircslack/irc_server.go
+++ b/pkg/ircslack/irc_server.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/coredhcp/coredhcp/logger"
@@ -169,9 +168,7 @@ func IrcSendChanInfoAfterJoin(ctx *IrcContext, name, id, topic string, members [
 	if err := SendIrcNumeric(ctx, 366, fmt.Sprintf("%s %s", ctx.Nick(), name), "End of NAMES list"); err != nil {
 		log.Warningf("Failed to send IRC message: %v", err)
 	}
-	ctx.ChanMutex.Lock()
 	log.Infof("Joined channel %s: %+v", name, ctx.Channels.ByName(name))
-	ctx.ChanMutex.Unlock()
 }
 
 func usersInConversation(ctx *IrcContext, conversation string) ([]string, error) {
@@ -324,8 +321,6 @@ func IrcAfterLoggingIn(ctx *IrcContext, rtm *slack.RTM) error {
 	if err := SendIrcNumeric(ctx, 376, ctx.Nick(), ""); err != nil {
 		log.Warningf("Failed to send IRC message: %v", err)
 	}
-
-	ctx.ChanMutex = &sync.Mutex{}
 
 	// get channels
 	if err := joinChannels(ctx); err != nil {


### PR DESCRIPTION
Let the GC reclaim the context content upon disconnection

Signed-off-by: Andrea Barberio <insomniac@slackware.it>