### PR TITLE
Added Dockerfile.autotoken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ LABEL RUN="docker run --rm -p 6666:6666 -it insomniacslk/irc-slack"
 # Install git.
 # Git is required for fetching the dependencies.
 RUN apk update && apk add --no-cache git bash make
-COPY . $GOPATH/src/insomniacslk/irc-slack
+COPY . $GOPATH/src/github.com/insomniacslk/irc-slack
 ENV GO111MODULE=on
-WORKDIR $GOPATH/src/insomniacslk/irc-slack/cmd/irc-slack
+WORKDIR $GOPATH/src/github.com/insomniacslk/irc-slack/cmd/irc-slack
 # Build the binary.
 RUN make
 RUN cp irc-slack /go/bin

--- a/Dockerfile.autotoken
+++ b/Dockerfile.autotoken
@@ -1,0 +1,21 @@
+############################
+# STEP 1 build executable binary
+############################
+FROM golang:1.16-alpine AS builder
+
+LABEL BUILD="docker build -t insomniacslk/irc-slack/tools-autotoken -f Dockerfile.autotoken ."
+LABEL RUN="docker run --rm -it insomniacslk/irc-slack/tools-autotoken"
+
+# Install git.
+# Git is required for fetching the dependencies.
+RUN apk update && apk add --no-cache --purge git bash chromium
+COPY . $GOPATH/src/github.com/insomniacslk/irc-slack/
+ENV GO111MODULE=on
+WORKDIR $GOPATH/src/github.com/insomniacslk/irc-slack/tools/autotoken
+# Build the binary.
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/autotoken
+ENV PATH="/go/bin:$PATH"
+WORKDIR /tmp
+USER guest
+# Run the autotoken binary.
+CMD ["/go/bin/autotoken", "-h"]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ and use the above as your IRC password.
 See [autotoken](tools/autotoken). Just build it with `go build` and run with
 `./autotoken -h` to see the usage help.
 
+If you prefer to run `autotoken` via Docker, run:
+```
+docker pull insomniacslk/irc-slack/tools-autotoken
+docker run --rm -it -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix insomniacslk/irc-slack/tools-autotoken autotoken -h
+```
+
 ### Slack App tokens
 
 As an alternative, you can install the irc-slack app on your workspace, and use the token that it returns after you authorize it.

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ and use the above as your IRC password.
 See [autotoken](tools/autotoken). Just build it with `go build` and run with
 `./autotoken -h` to see the usage help.
 
-If you prefer to run `autotoken` via Docker, run:
+If you prefer to run `autotoken` via Docker, you can test your luck with:
 ```
-docker pull insomniacslk/irc-slack/tools-autotoken
+docker build -t insomniacslk/irc-slack/tools-autotoken -f Dockerfile.autotoken .
 docker run --rm -it -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix insomniacslk/irc-slack/tools-autotoken autotoken -h
 ```
 


### PR DESCRIPTION
To run autotoken via Docker. The container includes Go and Chrome
headless, used by autotoken.
Also added --chrome-path to autotoken to allow for custom chromium path.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>