### PR TITLE
[docker] Build irc-slack using make instead of go build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.15', '1.16']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.15', '1.16']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.12-alpine AS builder
+FROM golang:1.16-alpine AS builder
 
 LABEL BUILD="docker build -t insomniacslk/irc-slack -f Dockerfile ."
 LABEL RUN="docker run --rm -p 6666:6666 -it insomniacslk/irc-slack"
 
 # Install git.
 # Git is required for fetching the dependencies.
-RUN apk update && apk add --no-cache git bash
+RUN apk update && apk add --no-cache git bash make
 COPY . $GOPATH/src/insomniacslk/irc-slack
 ENV GO111MODULE=on
 WORKDIR $GOPATH/src/insomniacslk/irc-slack/cmd/irc-slack
 # Build the binary.
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/irc-slack
+RUN make
+RUN cp irc-slack /go/bin
 
 ############################
 # STEP 2 build a small image

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please keep reporting bugs and sending PRs!
 
 ```
 cd cmd/irc-slack
-make
+make # use `make` instead of `go build` to include build information when running with `-v`
 ./irc-slack # by default on port 6666
 ```
 

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
@@ -616,6 +617,7 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Using make we also get build information, visible when running
`irc-slack -v`.

Also bumped Go version in the container to 1.16

Signed-off-by: Andrea Barberio <insomniac@slackware.it>